### PR TITLE
Test parameters on same bus

### DIFF
--- a/eggs_machina/hw_drivers/system/robstride/robstride.py
+++ b/eggs_machina/hw_drivers/system/robstride/robstride.py
@@ -47,7 +47,7 @@ class Robstride(System):
         )
 
     def set_motor_can_id(self, new_can_id: int):
-        can_frame_id = self.motor_can_id | (new_can_id << 8) | (new_can_id << 16) | ( Robstride_Msg_Enum.SET_CAN_ID << 24)
+        can_frame_id = self.motor_can_id | (new_can_id << 8) | (new_can_id << 16) | ( Robstride_Msg_Enum.SET_CAN_ID.value << 24)
         self.can_transport.send(can_id=can_frame_id, data=EMPTY_CAN_FRAME, is_extended_id=True)
 
     def set_motor_baud_rate(self, new_baud_rate: can_transport.CAN_Baud_Rate):

--- a/eggs_machina/hw_drivers/system/robstride/robstride.py
+++ b/eggs_machina/hw_drivers/system/robstride/robstride.py
@@ -187,10 +187,11 @@ class Robstride(System):
                 
 
 if __name__ == "__main__":
-    transport = can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS1, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
-    # can_channel = "can1"
-    # usb2can_transport = USB2CANX2(channel=can_channel, baud_rate=1000000)
-    robstride = Robstride(host_can_id=0xFD, motor_can_id=127, can_transport=transport)
+    # transport = can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS1, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
+    can_channel = "can1"
+    transport = USB2CANX2(channel=can_channel, baud_rate=1000000)
+    robstride = Robstride(host_can_id=0xFD, motor_can_id=126, can_transport=transport)
+    robstride2 = Robstride(host_can_id=0xFD, motor_can_id=127, can_transport=transport)
 
     # robstride.enable_motor()
     # robstride.move_to_position(
@@ -210,6 +211,9 @@ if __name__ == "__main__":
     print(pos)
     bus_voltage = robstride.read_single_param(Robstride_Param_Enum.VBUS_VOLTAGE)
     print(bus_voltage)
+    bus_voltage2 = robstride2.read_single_param(Robstride_Param_Enum.VBUS_VOLTAGE)
+    print(bus_voltage2)
+    # robstride.set_motor_can_id(126)
 
     def test_position_control(robstride: Robstride):
         robstride.write_single_param(Robstride_Param_Enum.RUN_MODE, 1)
@@ -223,10 +227,10 @@ if __name__ == "__main__":
         pos = robstride.read_single_param(Robstride_Param_Enum.MECH_POS_END_COIL)
         print(pos)
 
-    test_position_control(robstride)
+    # test_position_control(robstride)
     # robstride.write_single_param(Robstride_Param_Enum.RUN_MODE, 0)      
     # control_mode = robstride.read_single_param(Robstride_Param_Enum.RUN_MODE)   # TODO: Fix reading empty frame for parameter right after changing it (such as in these 2 lines)
-    print(control_mode)
+    # print(control_mode)
 
-    #usb2can_transport.close_channel(can_channel)
+    transport.close_channel(can_channel)
 

--- a/eggs_machina/scripts/teleop.py
+++ b/eggs_machina/scripts/teleop.py
@@ -10,7 +10,9 @@ from eggs_machina.hw_drivers.system.robstride.robstride_types import FeedbackRes
 import time
 
 def set_position(leader: Robstride, follower: Robstride):
+    print()
     pos = leader.read_single_param(Robstride_Param_Enum.MECH_POS_END_COIL)
+    print(f"Read pos:{pos}, writing to follower")
     follower.write_single_param(Robstride_Param_Enum.POSITION_MODE_ANGLE_CMD, pos)
 
 def instantiate_transport() -> Transport:

--- a/eggs_machina/scripts/teleop.py
+++ b/eggs_machina/scripts/teleop.py
@@ -12,6 +12,15 @@ def set_position(leader: Robstride, follower: Robstride):
     pos = leader.read_single_param(Robstride_Param_Enum.MECH_POS_END_COIL)
     follower.write_single_param(Robstride_Param_Enum.POSITION_MODE_ANGLE_CMD, pos)
 
+def instantiate_transport() -> Transport:
+    channel = "can1"
+    transport = USB2CANX2(channel=channel, baud_rate=1000000)
+    return transport, channel
+
+def shutdown_transport(transport: Transport, can_channel):
+    """Gracefully shutdown the transport channel."""
+    transport.close_channel(can_channel)
+
 
 def instantiate_robots() -> List[Any]:
     """Define and instantiate all robots used during teleop."""
@@ -57,12 +66,13 @@ def shutdown_robots_gracefully(robots: List[Any]):
 
 
 if __name__ == "__main__":
-    robots = instantiate_robots()
+    transport, channel = instantiate_transport()
     try:
         main()
     except KeyboardInterrupt:
         print("Shutdown requested...exiting")
         shutdown_robots_gracefully(robots)
+        shutdown_transport(transport, channel)
         try:
             sys.exit(130)
         except SystemExit:

--- a/eggs_machina/scripts/teleop.py
+++ b/eggs_machina/scripts/teleop.py
@@ -22,20 +22,20 @@ def shutdown_transport(transport: Transport, can_channel):
     transport.close_channel(can_channel)
 
 
-def instantiate_robots() -> List[Any]:
+def instantiate_robots(transport: Transport) -> List[Any]:
     """Define and instantiate all robots used during teleop."""
-    transport =  can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS2, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
-    transport2 =  can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS1, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
-    host_can_id = 150
-    # TODO: set control mode to position
-    # TODO: enable motor
+    # transport =  can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS2, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
+    # transport2 =  can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS1, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
+    host_can_id = 0xFD
     leader = Robstride(transport, host_can_id, motor_can_id=127)
     follower = Robstride(transport2, host_can_id, motor_can_id=127)
     follower.write_single_param(Robstride_Param_Enum.RUN_MODE, 1)
     leader.stop_motor()
-    follower.enable_motor()   
+    follower.enable_motor()
+    time.sleep(0.05)   
     set_position(leader, follower)
     time.sleep(1)
+    follower.stop_motor()  
     return [leader, follower]
 
 
@@ -52,23 +52,24 @@ def teleop(leader: Robstride, follower: Robstride):
         time.sleep(0.05)
 
 
-def main():
-    robots = instantiate_robots()
+def main(robots):
     leader = robots[0]
     follower = robots[1]
     start_teleop(leader, follower)
 
 
-
 def shutdown_robots_gracefully(robots: List[Any]):
     """Gracefully turn off all robots."""
+    for robot in robots:
+        robot.stop_motor()
     pass
 
 
 if __name__ == "__main__":
     transport, channel = instantiate_transport()
+    robots = instantiate_robots(transport)
     try:
-        main()
+        main(robots)
     except KeyboardInterrupt:
         print("Shutdown requested...exiting")
         shutdown_robots_gracefully(robots)
@@ -77,3 +78,7 @@ if __name__ == "__main__":
             sys.exit(130)
         except SystemExit:
             os._exit(130)
+    except Exception as e:
+        print("Exception occurred, shutting down transport...")
+        shutdown_transport(transport, channel)
+        print(e)

--- a/eggs_machina/scripts/teleop.py
+++ b/eggs_machina/scripts/teleop.py
@@ -5,6 +5,7 @@ from eggs_machina.hw_drivers.system.robstride.robstride import Robstride
 from eggs_machina.hw_drivers.transport.can import PCANBasic
 from eggs_machina.hw_drivers.transport.base import Transport
 from eggs_machina.hw_drivers.transport.can import can_transport
+from eggs_machina.hw_drivers.transport.can.usb2can_x2 import USB2CANX2
 from eggs_machina.hw_drivers.system.robstride.robstride_types import FeedbackResp, Robstride_Fault_Enum, Robstride_Fault_Frame_Enum, Robstride_Motor_Mode_Enum, Robstride_Msg_Enum, Robstride_Param_Enum
 import time
 
@@ -28,7 +29,11 @@ def instantiate_robots(transport: Transport) -> List[Any]:
     # transport2 =  can_transport.PCAN(channel=PCANBasic.PCAN_USBBUS1, baud_rate=can_transport.CAN_Baud_Rate.CAN_BAUD_1_MBS)
     host_can_id = 0xFD
     leader = Robstride(transport, host_can_id, motor_can_id=127)
-    follower = Robstride(transport2, host_can_id, motor_can_id=127)
+    follower = Robstride(transport, host_can_id, motor_can_id=126)
+    leader_bus_voltage = leader.read_single_param(Robstride_Param_Enum.VBUS_VOLTAGE)
+    print(f"leader_bus_voltage: {leader_bus_voltage}")
+    follower_bus_voltage = follower.read_single_param(Robstride_Param_Enum.VBUS_VOLTAGE)
+    print(f"follower_bus_voltage: {follower_bus_voltage}")
     follower.write_single_param(Robstride_Param_Enum.RUN_MODE, 1)
     leader.stop_motor()
     follower.enable_motor()

--- a/eggs_machina/scripts/teleop.py
+++ b/eggs_machina/scripts/teleop.py
@@ -69,7 +69,6 @@ def shutdown_robots_gracefully(robots: List[Any]):
     """Gracefully turn off all robots."""
     for robot in robots:
         robot.stop_motor()
-    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fixed issue of reading empty frames after writing. Solution proposed here is to just retry reading several times.
* Tested teleop with servos on the same bus